### PR TITLE
Fix snackbar auto-dismiss issue for todo deletion

### DIFF
--- a/app/src/main/java/com/ashmit/todolist/ui/add_edit_todo/AddEditTodoViewModel.kt
+++ b/app/src/main/java/com/ashmit/todolist/ui/add_edit_todo/AddEditTodoViewModel.kt
@@ -1,5 +1,6 @@
 package com.ashmit.todolist.ui.add_edit_todo
 
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -57,7 +58,8 @@ class AddEditTodoViewModel @Inject constructor(
                     if(title.isBlank()){
                         sendUiEvent(
                             UiEvent.ShowSnackBar(
-                            message = "The title Cant be Empty"
+                            message = "The title Cant be Empty",
+                                duration = SnackbarDuration.Short
                         ))
                         return@launch
                     }

--- a/app/src/main/java/com/ashmit/todolist/ui/todo_list/TodoListScreen.kt
+++ b/app/src/main/java/com/ashmit/todolist/ui/todo_list/TodoListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -40,7 +41,8 @@ fun TodoListScreen(
                 is UiEvent.ShowSnackBar -> {
                     val result = snackbarHostState.showSnackbar(
                         message = event.message,
-                        actionLabel = event.action
+                        actionLabel = event.action,
+                        duration = SnackbarDuration.Short
                     )
                     if (result == SnackbarResult.ActionPerformed) {
                         viewModel.onEvent(TodoListEvent.onUndoDeleteClick)

--- a/app/src/main/java/com/ashmit/todolist/ui/todo_list/TodoListViewModel.kt
+++ b/app/src/main/java/com/ashmit/todolist/ui/todo_list/TodoListViewModel.kt
@@ -1,5 +1,6 @@
 package com.ashmit.todolist.ui.todo_list
 
+import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ashmit.todolist.data.Todo
@@ -41,7 +42,8 @@ Channels are used here to send one-time UI events, like showing a snackbar or na
                     sendUiEvent(
                         UiEvent.ShowSnackBar(
                         message = "Todo deleted",
-                        action = "Undo"
+                        action = "Undo",
+                            duration = SnackbarDuration.Short
                     ))
                 }
             }

--- a/app/src/main/java/com/ashmit/todolist/util/UiEvent.kt
+++ b/app/src/main/java/com/ashmit/todolist/util/UiEvent.kt
@@ -1,5 +1,7 @@
 package com.ashmit.todolist.util
 
+import androidx.compose.material3.SnackbarDuration
+
 /*A sealed class in Kotlin is a special kind of class that allows you to define a restricted hierarchy of classes. All subclasses of a sealed class are known at compile-time, which makes it easier to manage and handle different types of events or states in your code.
 
 Why Sealed Classes for UI Events?
@@ -12,7 +14,8 @@ sealed class UiEvent {
     data class Navigate(val route :String): UiEvent()
     data class ShowSnackBar(
         val message :String,
-        val action :String? = null
+        val action :String? = null,
+        val duration:SnackbarDuration
         ): UiEvent()
 }
 


### PR DESCRIPTION
Issue:

The snackbar that appears when a user deletes a todo item was not auto-dismissing after the specified duration. It remained on the screen until manually dismissed, which negatively affected user experience.
The background task associated with the snackbar did not respond as expected, causing delays in dismissing the snackbar.
Additionally, users were unable to manually dismiss the snackbar, leading to further frustration.